### PR TITLE
Add support for fetching tasks by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # MCP Server for Asana
 
 [![npm version](https://badge.fury.io/js/%40roychri%2Fmcp-server-asana.svg)](https://www.npmjs.com/package/@roychri/mcp-server-asana)
@@ -155,6 +154,16 @@ Another example:
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of detailed task information
+16. `asana_get_tasks_for_tag`
+    * Get tasks for a specific tag
+    * Required input:
+        * tag_gid (string): The tag GID to retrieve tasks for
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+        * opt_pretty (boolean): Provides the response in a 'pretty' format
+        * limit (integer): The number of objects to return per page. The value must be between 1 and 100.
+        * offset (string): An offset to the next page returned by the API.
+    * Returns: List of tasks for the specified tag
 
 ## Prompts
 

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -171,4 +171,9 @@ export class AsanaClientWrapper {
 
     return tasks;
   }
+
+  async getTasksForTag(tag_gid: string, opts: any = {}) {
+    const response = await this.tasks.getTasksForTag(tag_gid, opts);
+    return response.data;
+  }
 }

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -14,7 +14,8 @@ import {
   createTaskTool,
   updateTaskTool,
   createSubtaskTool,
-  getMultipleTasksByGidTool
+  getMultipleTasksByGidTool,
+  getTasksForTagTool
 } from './tools/task-tools.js';
 import {
   addTaskDependenciesTool,
@@ -41,6 +42,7 @@ export const list_of_tools: Tool[] = [
   addTaskDependentsTool,
   createSubtaskTool,
   getMultipleTasksByGidTool,
+  getTasksForTagTool,
 ];
 
 export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToolRequest) => Promise<CallToolResult> {
@@ -177,6 +179,14 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
               ? task_ids
               : task_ids.split(',').map((id: string) => id.trim()).filter((id: string) => id.length > 0);
             const response = await asanaClient.getMultipleTasksByGid(taskIdList, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_get_tasks_for_tag": {
+            const { tag_gid, ...opts } = args;
+            const response = await asanaClient.getTasksForTag(tag_gid, opts);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -401,3 +401,34 @@ export const getMultipleTasksByGidTool: Tool = {
     required: ["task_ids"]
   }
 };
+
+export const getTasksForTagTool: Tool = {
+  name: "asana_get_tasks_for_tag",
+  description: "Get tasks for a specific tag",
+  inputSchema: {
+    type: "object",
+    properties: {
+      tag_gid: {
+        type: "string",
+        description: "The tag GID to retrieve tasks for"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      },
+      opt_pretty: {
+        type: "boolean",
+        description: "Provides the response in a 'pretty' format"
+      },
+      limit: {
+        type: "integer",
+        description: "The number of objects to return per page. The value must be between 1 and 100."
+      },
+      offset: {
+        type: "string",
+        description: "An offset to the next page returned by the API."
+      }
+    },
+    required: ["tag_gid"]
+  }
+};


### PR DESCRIPTION
Add support for fetching tasks by tag in Asana.

* **`src/tools/task-tools.ts`**
  - Add a new tool definition for `asana_get_tasks_for_tag` to fetch tasks by tag.
  - Include required input `tag_gid` and optional inputs `opt_fields`, `opt_pretty`, `limit`, and `offset`.

* **`src/tool-handler.ts`**
  - Add a case for `asana_get_tasks_for_tag` in the tool handler switch statement.
  - Call the `getTasksForTag` method from `AsanaClientWrapper` with the provided arguments.

* **`src/asana-client-wrapper.ts`**
  - Add a new method `getTasksForTag` to fetch tasks by tag using the Asana API.
  - Accept `tag_gid` and optional parameters `opt_fields`, `opt_pretty`, `limit`, and `offset`.

* **`README.md`**
  - Add a new tool `asana_get_tasks_for_tag` to the list of tools.
  - Include its description, required input, optional input, and return values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/roychri/mcp-server-asana/pull/1?shareId=eda0ed26-28a1-4c64-83f2-ecbbbc048c4b).