### PR TITLE
Add a new tool for setting the parent of a task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # MCP Server for Asana
 
 [![npm version](https://badge.fury.io/js/%40roychri%2Fmcp-server-asana.svg)](https://www.npmjs.com/package/@roychri/mcp-server-asana)
@@ -190,6 +189,16 @@ Another example:
     * Required input:
         * project_status_gid (string): The project status GID to delete
     * Returns: Deletion confirmation
+20. `asana_set_parent_for_task`
+    * Set the parent of a task and position the subtask within the other subtasks of that parent
+    * Required input:
+        * task_id (string): The task ID to operate on
+        * parent (string): The new parent of the task, or null for no parent
+    * Optional input:
+        * insert_after (string): A subtask of the parent to insert the task after, or null to insert at the beginning of the list
+        * insert_before (string): A subtask of the parent to insert the task before, or null to insert at the end of the list
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Updated task information
 
 ## Prompts
 

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -201,6 +201,11 @@ export class AsanaClientWrapper {
     return response.data;
   }
 
+  async setParentForTask(data: any, taskId: string, opts: any = {}) {
+    const response = await this.tasks.setParentForTask({ data }, taskId, opts);
+    return response.data;
+  }
+
   async getProjectStatus(statusId: string, opts: any = {}) {
     const response = await this.projectStatuses.getProjectStatus(statusId, opts);
     return response.data;

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -24,7 +24,8 @@ import {
 } from './tools/task-tools.js';
 import {
   addTaskDependenciesTool,
-  addTaskDependentsTool
+  addTaskDependentsTool,
+  setParentForTaskTool
 } from './tools/task-relationship-tools.js';
 import {
   getStoriesForTaskTool,
@@ -50,7 +51,8 @@ export const list_of_tools: Tool[] = [
   getProjectStatusTool,
   getProjectStatusesForProjectTool,
   createProjectStatusTool,
-  deleteProjectStatusTool
+  deleteProjectStatusTool,
+  setParentForTaskTool
 ];
 
 export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToolRequest) => Promise<CallToolResult> {
@@ -219,6 +221,14 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
               ? task_ids
               : task_ids.split(',').map((id: string) => id.trim()).filter((id: string) => id.length > 0);
             const response = await asanaClient.getMultipleTasksByGid(taskIdList, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_set_parent_for_task": {
+            const { task_id, ...parentData } = args;
+            const response = await asanaClient.setParentForTask(task_id, parentData);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -227,8 +227,14 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
           }
 
           case "asana_set_parent_for_task": {
-            const { task_id, ...parentData } = args;
-            const response = await asanaClient.setParentForTask(task_id, parentData);
+            let { data, task_id, opts } = args;
+            if ( typeof data == "string" ) {
+              data = JSON.parse( data );
+            }
+            if ( typeof opts == "string" ) {
+              opts = JSON.parse( opts );
+            }
+            const response = await asanaClient.setParentForTask(data, task_id, opts);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tools/task-relationship-tools.ts
+++ b/src/tools/task-relationship-tools.ts
@@ -43,3 +43,35 @@ export const addTaskDependentsTool: Tool = {
     required: ["task_id", "dependents"]
   }
 };
+
+export const setParentForTaskTool: Tool = {
+  name: "asana_set_parent_for_task",
+  description: "Set the parent of a task and position the subtask within the other subtasks of that parent",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description: "The task ID to operate on"
+      },
+      parent: {
+        type: "string",
+        description: "The new parent of the task, or null for no parent",
+        required: true
+      },
+      insert_after: {
+        type: "string",
+        description: "A subtask of the parent to insert the task after, or null to insert at the beginning of the list"
+      },
+      insert_before: {
+        type: "string",
+        description: "A subtask of the parent to insert the task before, or null to insert at the end of the list"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["task_id", "parent"]
+  }
+};

--- a/src/tools/task-relationship-tools.ts
+++ b/src/tools/task-relationship-tools.ts
@@ -76,6 +76,6 @@ export const setParentForTaskTool: Tool = {
         }
       }
     },
-    required: ["task_id", "parent"]
+    required: ["task_id", "data"]
   }
 };

--- a/src/tools/task-relationship-tools.ts
+++ b/src/tools/task-relationship-tools.ts
@@ -50,26 +50,30 @@ export const setParentForTaskTool: Tool = {
   inputSchema: {
     type: "object",
     properties: {
+      data: {
+        parent: {
+          type: "string",
+          description: "The GID of the new parent of the task, or null for no parent",
+          required: true
+        },
+        insert_after: {
+          type: "string",
+          description: "A subtask of the parent to insert the task after, or null to insert at the beginning of the list. Cannot be used with insert_before. The task must already be set as a subtask of that parent."
+        },
+        insert_before: {
+          type: "string",
+          description: "A subtask of the parent to insert the task before, or null to insert at the end of the list. Cannot be used with insert_after. The task must already be set as a subtask of that parent."
+        },
+      },
       task_id: {
         type: "string",
         description: "The task ID to operate on"
       },
-      parent: {
-        type: "string",
-        description: "The new parent of the task, or null for no parent",
-        required: true
-      },
-      insert_after: {
-        type: "string",
-        description: "A subtask of the parent to insert the task after, or null to insert at the beginning of the list"
-      },
-      insert_before: {
-        type: "string",
-        description: "A subtask of the parent to insert the task before, or null to insert at the end of the list"
-      },
-      opt_fields: {
-        type: "string",
-        description: "Comma-separated list of optional fields to include"
+      opts: {
+        opt_fields: {
+          type: "string",
+          description: "Comma-separated list of optional fields to include"
+        }
       }
     },
     required: ["task_id", "parent"]


### PR DESCRIPTION
Add a new tool to set the parent of a task and position the subtask within the other subtasks of that parent.

* **src/tools/task-relationship-tools.ts**
  - Add `setParentForTaskTool` function to set the parent of a task.
  - Include required and optional input parameters for the tool.
  - Add the new tool to the export list.

* **src/tool-handler.ts**
  - Import `setParentForTaskTool` from `src/tools/task-relationship-tools.ts`.
  - Add the new tool to the `list_of_tools` array.
  - Add a case for the new tool in the `tool_handler` function.

* **README.md**
  - Add the new tool to the list of tools in the README.
  - Include the description, required and optional input, and return values for the new tool.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/roychri/mcp-server-asana/pull/6?shareId=882e2f67-1653-4fe6-9b84-1207ee601f70).