### PR TITLE
feat(tag-tools): Add tag creation and management capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,28 @@ Another example:
         * offset (string): Offset token. An offset to the next page returned by the API.
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of tags in the workspace
+23. `asana_create_tag`
+    * Create a new tag in a workspace
+    * Required input:
+        * workspace_gid (string): Globally unique identifier for the workspace or organization
+        * name (string): Name of the tag
+    * Optional input:
+        * color (string): Color of the tag. Can be one of: dark-pink, dark-green, dark-blue, dark-red, dark-teal, dark-brown, dark-orange, dark-purple, dark-warm-gray, light-pink, light-green, light-blue, light-red, light-teal, light-brown, light-orange, light-purple, light-warm-gray
+        * notes (string): Notes about the tag
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Created tag information
+24. `asana_add_tag_to_task`
+    * Add a tag to a task
+    * Required input:
+        * task_gid (string): The task GID to add the tag to
+        * tag_gid (string): The tag GID to add to the task
+    * Returns: Success response
+25. `asana_remove_tag_from_task`
+    * Remove a tag from a task
+    * Required input:
+        * task_gid (string): The task GID to remove the tag from
+        * tag_gid (string): The tag GID to remove from the task
+    * Returns: Success response
 
 ## Prompts
 

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -286,4 +286,35 @@ export class AsanaClientWrapper {
     const response = await this.tags.getTagsForWorkspace(workspace_gid, opts);
     return response.data;
   }
+
+  async createTag(workspace_gid: string, data: any) {
+    const tagData = {
+      data: {
+        ...data,
+        workspace: workspace_gid
+      }
+    };
+    const response = await this.tags.createTag(tagData);
+    return response.data;
+  }
+
+  async addTagToTask(task_gid: string, tag_gid: string) {
+    const body = {
+      data: {
+        tag: tag_gid
+      }
+    };
+    const response = await this.tasks.addTagForTask(body, task_gid);
+    return response.data;
+  }
+
+  async removeTagFromTask(task_gid: string, tag_gid: string) {
+    const body = {
+      data: {
+        tag: tag_gid
+      }
+    };
+    const response = await this.tasks.removeTagForTask(body, task_gid);
+    return response.data;
+  }
 }

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -22,7 +22,7 @@ import {
   createSubtaskTool,
   getMultipleTasksByGidTool
 } from './tools/task-tools.js';
-import { getTasksForTagTool, getTagsForWorkspaceTool } from './tools/tag-tools.js';
+import { getTasksForTagTool, getTagsForWorkspaceTool, createTagTool, addTagToTaskTool, removeTagFromTaskTool } from './tools/tag-tools.js';
 import {
   addTaskDependenciesTool,
   addTaskDependentsTool,
@@ -56,6 +56,9 @@ export const list_of_tools: Tool[] = [
   setParentForTaskTool,
   getTasksForTagTool,
   getTagsForWorkspaceTool,
+  createTagTool,
+  addTagToTaskTool,
+  removeTagFromTaskTool,
 ];
 
 export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToolRequest) => Promise<CallToolResult> {
@@ -254,6 +257,30 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
           case "asana_get_tags_for_workspace": {
             const { workspace_gid, ...opts } = args;
             const response = await asanaClient.getTagsForWorkspace(workspace_gid, opts);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_create_tag": {
+            const { workspace_gid, ...tagData } = args;
+            const response = await asanaClient.createTag(workspace_gid, tagData);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_add_tag_to_task": {
+            const { task_gid, tag_gid } = args;
+            const response = await asanaClient.addTagToTask(task_gid, tag_gid);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          }
+
+          case "asana_remove_tag_from_task": {
+            const { task_gid, tag_gid } = args;
+            const response = await asanaClient.removeTagFromTask(task_gid, tag_gid);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -57,3 +57,72 @@ export const getTasksForTagTool: Tool = {
     required: ["tag_gid"]
   }
 };
+
+export const createTagTool: Tool = {
+  name: "asana_create_tag",
+  description: "Create a new tag in a workspace",
+  inputSchema: {
+    type: "object",
+    properties: {
+      workspace_gid: {
+        type: "string",
+        description: "Globally unique identifier for the workspace or organization"
+      },
+      name: {
+        type: "string",
+        description: "Name of the tag"
+      },
+      color: {
+        type: "string",
+        description: "Color of the tag (optional). Can be one of: dark-pink, dark-green, dark-blue, dark-red, dark-teal, dark-brown, dark-orange, dark-purple, dark-warm-gray, light-pink, light-green, light-blue, light-red, light-teal, light-brown, light-orange, light-purple, light-warm-gray"
+      },
+      notes: {
+        type: "string",
+        description: "Notes about the tag (optional)"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["workspace_gid", "name"]
+  }
+};
+
+export const addTagToTaskTool: Tool = {
+  name: "asana_add_tag_to_task",
+  description: "Add a tag to a task",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_gid: {
+        type: "string",
+        description: "The task GID to add the tag to"
+      },
+      tag_gid: {
+        type: "string",
+        description: "The tag GID to add to the task"
+      }
+    },
+    required: ["task_gid", "tag_gid"]
+  }
+};
+
+export const removeTagFromTaskTool: Tool = {
+  name: "asana_remove_tag_from_task",
+  description: "Remove a tag from a task",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_gid: {
+        type: "string",
+        description: "The task GID to remove the tag from"
+      },
+      tag_gid: {
+        type: "string",
+        description: "The tag GID to remove from the task"
+      }
+    },
+    required: ["task_gid", "tag_gid"]
+  }
+};


### PR DESCRIPTION
## Overview
This PR adds tag creation and management capabilities to the existing tag functionality in the Asana MCP server.

## New Features
- `asana_create_tag`: Create a new tag in a workspace with custom name, color, and notes
- `asana_add_tag_to_task`: Associate an existing tag with a task
- `asana_remove_tag_from_task`: Remove a tag association from a task

## Details
These new tools complement the existing tag-related tools (`asana_get_tags_for_workspace` and `asana_get_tasks_for_tag`) by providing full CRUD operations for Asana tags. Users can now create tags, apply them to tasks, and remove them when needed.

## Changes
- Added new tool definitions in `src/tools/tag-tools.ts`
- Implemented API methods in `src/asana-client-wrapper.ts`
- Updated tool handlers in `src/tool-handler.ts`
- Updated documentation in `README.md` with details on the new tools