### PR TITLE
Feat/read only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ More details on MCP here:
 
 <a href="https://glama.ai/mcp/servers/ln1qzdhwmc"><img width="380" height="200" src="https://glama.ai/mcp/servers/ln1qzdhwmc/badge" alt="mcp-server-asana MCP server" /></a>
 
+## Environment Variables
+
+- `ASANA_ACCESS_TOKEN`: (Required) Your Asana access token
+- `READ_ONLY_MODE`: (Optional) Set to 'true' to disable all write operations. In this mode, tools that modify Asana data (create, update, delete) will be disabled. This is useful for testing or when you want to ensure no changes can be made to your Asana workspace.
+
 ## Usage
 
 In the AI tool of your choice (ex: Claude Desktop) ask something about asana tasks, projects, workspaces, and/or comments. Mentioning the word "asana" will increase the chance of having the LLM pick the right tool.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ More details on MCP here:
 ## Environment Variables
 
 - `ASANA_ACCESS_TOKEN`: (Required) Your Asana access token
-- `READ_ONLY_MODE`: (Optional) Set to 'true' to disable all write operations. In this mode, tools that modify Asana data (create, update, delete) will be disabled. This is useful for testing or when you want to ensure no changes can be made to your Asana workspace.
+- `READ_ONLY_MODE`: (Optional) Set to 'true' to disable all write operations. In this mode:
+  - Tools that modify Asana data (create, update, delete) will be disabled
+  - The `create-task` prompt will be disabled
+  - Only read operations will be available
+  This is useful for testing or when you want to ensure no changes can be made to your Asana workspace.
 
 ## Usage
 

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -60,282 +60,77 @@ export const list_of_tools: Tool[] = [
 ];
 
 export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToolRequest) => Promise<CallToolResult> {
-    return async (request: CallToolRequest) => {
-      console.error("Received CallToolRequest:", request);
-      try {
-        if (!request.params.arguments) {
-          throw new Error("No arguments provided");
+  return async (request: CallToolRequest) => {
+    console.error("Received CallToolRequest:", request);
+    try {
+      if (!request.params.arguments) {
+        throw new Error("No arguments provided");
+      }
+
+      const args = request.params.arguments as any;
+
+      switch (request.params.name) {
+        case "asana_list_workspaces": {
+          const response = await asanaClient.listWorkspaces(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
         }
 
-        const args = request.params.arguments as any;
+        case "asana_search_projects": {
+          const { workspace, name_pattern, archived = false, ...opts } = args;
+          const response = await asanaClient.searchProjects(
+            workspace,
+            name_pattern,
+            archived,
+            opts
+          );
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
 
-        switch (request.params.name) {
-          case "asana_list_workspaces": {
-            const response = await asanaClient.listWorkspaces(args);
+        case "asana_search_tasks": {
+          const { workspace, ...searchOpts } = args;
+          const response = await asanaClient.searchTasks(workspace, searchOpts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_task": {
+          const { task_id, ...opts } = args;
+          const response = await asanaClient.getTask(task_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_create_task": {
+          const { project_id, ...taskData } = args;
+          try {
+            const response = await asanaClient.createTask(project_id, taskData);
             return {
               content: [{ type: "text", text: JSON.stringify(response) }],
             };
-          }
-
-          case "asana_search_projects": {
-            const { workspace, name_pattern, archived = false, ...opts } = args;
-            const response = await asanaClient.searchProjects(
-              workspace,
-              name_pattern,
-              archived,
-              opts
-            );
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_search_tasks": {
-            const { workspace, ...searchOpts } = args;
-            const response = await asanaClient.searchTasks(workspace, searchOpts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_task": {
-            const { task_id, ...opts } = args;
-            const response = await asanaClient.getTask(task_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_create_task": {
-            const { project_id, ...taskData } = args;
-            try {
-              const response = await asanaClient.createTask(project_id, taskData);
-              return {
-                content: [{ type: "text", text: JSON.stringify(response) }],
-              };
-            } catch (error) {
-              // When error occurs and html_notes was provided, validate it
-              if (taskData.html_notes && error instanceof Error && [400,500].includes( error.status ) ) {
-                const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
-                if (xmlValidationErrors.length > 0) {
-                  // Provide detailed validation errors to help the user
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: error instanceof Error ? error.message : String(error),
-                        validation_errors: xmlValidationErrors,
-                        message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
-                      })
-                    }],
-                  };
-                } else {
-                  // HTML is valid, something else caused the error
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: error instanceof Error ? error.message : String(error),
-                        html_notes_validation: "The HTML notes format is valid. The error must be related to something else."
-                      })
-                    }],
-                  };
-                }
-              }
-              throw error; // re-throw to be caught by the outer try/catch
-            }
-          }
-
-          case "asana_get_task_stories": {
-            const { task_id, ...opts } = args;
-            const response = await asanaClient.getStoriesForTask(task_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_update_task": {
-            const { task_id, ...taskData } = args;
-            try {
-              const response = await asanaClient.updateTask(task_id, taskData);
-              return {
-                content: [{ type: "text", text: JSON.stringify(response) }],
-              };
-            } catch (error) {
-              // When error occurs and html_notes was provided, validate it
-              if (taskData.html_notes && error instanceof Error && error.message.includes('400')) {
-                const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
-                if (xmlValidationErrors.length > 0) {
-                  // Provide detailed validation errors to help the user
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: error instanceof Error ? error.message : String(error),
-                        validation_errors: xmlValidationErrors,
-                        message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
-                      })
-                    }],
-                  };
-                } else {
-                  // HTML is valid, something else caused the error
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: error instanceof Error ? error.message : String(error),
-                        html_notes_validation: "The HTML notes format is valid. The error must be related to something else."
-                      })
-                    }],
-                  };
-                }
-              }
-              throw error; // re-throw to be caught by the outer try/catch
-            }
-          }
-
-          case "asana_get_project": {
-            const { project_id, ...opts } = args;
-            const response = await asanaClient.getProject(project_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_project_task_counts": {
-            const { project_id, ...opts } = args;
-            const response = await asanaClient.getProjectTaskCounts(project_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_project_status": {
-            const { project_status_gid, ...opts } = args;
-            const response = await asanaClient.getProjectStatus(project_status_gid, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_project_statuses": {
-            const { project_gid, ...opts } = args;
-            const response = await asanaClient.getProjectStatusesForProject(project_gid, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_create_project_status": {
-            const { project_gid, ...statusData } = args;
-            const response = await asanaClient.createProjectStatus(project_gid, statusData);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_delete_project_status": {
-            const { project_status_gid } = args;
-            const response = await asanaClient.deleteProjectStatus(project_status_gid);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_project_sections": {
-            const { project_id, ...opts } = args;
-            const response = await asanaClient.getProjectSections(project_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_create_task_story": {
-            const { task_id, text, html_text, ...opts } = args;
-
-            try {
-              // Validate if html_text is provided
-              if (html_text) {
-                const xmlValidationErrors = validateAsanaXml(html_text);
-                if (xmlValidationErrors.length > 0) {
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: "HTML validation failed",
-                        validation_errors: xmlValidationErrors,
-                        message: "The HTML text contains invalid XML formatting. Please check the validation errors above."
-                      })
-                    }],
-                  };
-                }
-              }
-
-              const response = await asanaClient.createTaskStory(task_id, text, opts, html_text);
-              return {
-                content: [{ type: "text", text: JSON.stringify(response) }],
-              };
-            } catch (error) {
-              // When error occurs and html_text was provided, help troubleshoot
-              if (html_text && error instanceof Error && error.message.includes('400')) {
+          } catch (error) {
+            // When error occurs and html_notes was provided, validate it
+            if (taskData.html_notes && error instanceof Error && [400, 500].includes(error.status)) {
+              const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
+              if (xmlValidationErrors.length > 0) {
+                // Provide detailed validation errors to help the user
                 return {
                   content: [{
                     type: "text",
                     text: JSON.stringify({
                       error: error instanceof Error ? error.message : String(error),
-                      html_text_validation: "The HTML format is valid. The error must be related to something else in the API request."
+                      validation_errors: xmlValidationErrors,
+                      message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
                     })
                   }],
                 };
-              }
-              throw error; // re-throw to be caught by the outer try/catch
-            }
-          }
-
-          case "asana_add_task_dependencies": {
-            const { task_id, dependencies } = args;
-            const response = await asanaClient.addTaskDependencies(task_id, dependencies);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_add_task_dependents": {
-            const { task_id, dependents } = args;
-            const response = await asanaClient.addTaskDependents(task_id, dependents);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_create_subtask": {
-            const { parent_task_id, opt_fields, ...taskData } = args;
-
-            try {
-              // Validate html_notes if provided
-              if (taskData.html_notes) {
-                const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
-                if (xmlValidationErrors.length > 0) {
-                  return {
-                    content: [{
-                      type: "text",
-                      text: JSON.stringify({
-                        error: "HTML validation failed",
-                        validation_errors: xmlValidationErrors,
-                        message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
-                      })
-                    }],
-                  };
-                }
-              }
-
-              const response = await asanaClient.createSubtask(parent_task_id, taskData, { opt_fields });
-              return {
-                content: [{ type: "text", text: JSON.stringify(response) }],
-              };
-            } catch (error) {
-              // When error occurs and html_notes was provided, help troubleshoot
-              if (taskData.html_notes && error instanceof Error && error.message.includes('400')) {
+              } else {
+                // HTML is valid, something else caused the error
                 return {
                   content: [{
                     type: "text",
@@ -346,71 +141,276 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
                   }],
                 };
               }
-              throw error; // re-throw to be caught by the outer try/catch
             }
+            throw error; // re-throw to be caught by the outer try/catch
           }
-
-          case "asana_get_multiple_tasks_by_gid": {
-            const { task_ids, ...opts } = args;
-            // Handle both array and string input
-            const taskIdList = Array.isArray(task_ids)
-              ? task_ids
-              : task_ids.split(',').map((id: string) => id.trim()).filter((id: string) => id.length > 0);
-            const response = await asanaClient.getMultipleTasksByGid(taskIdList, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_set_parent_for_task": {
-            let { data, task_id, opts } = args;
-            if ( typeof data == "string" ) {
-              data = JSON.parse( data );
-            }
-            if ( typeof opts == "string" ) {
-              opts = JSON.parse( opts );
-            }
-            const response = await asanaClient.setParentForTask(data, task_id, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_tasks_for_tag": {
-            const { tag_gid, ...opts } = args;
-            const response = await asanaClient.getTasksForTag(tag_gid, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          case "asana_get_tags_for_workspace": {
-            const { workspace_gid, ...opts } = args;
-            const response = await asanaClient.getTagsForWorkspace(workspace_gid, opts);
-            return {
-              content: [{ type: "text", text: JSON.stringify(response) }],
-            };
-          }
-
-          default:
-            throw new Error(`Unknown tool: ${request.params.name}`);
         }
-      } catch (error) {
-        console.error("Error executing tool:", error);
 
-        // Default error response
-        const errorResponse = {
-          error: error instanceof Error ? error.message : String(error),
-        };
+        case "asana_get_task_stories": {
+          const { task_id, ...opts } = args;
+          const response = await asanaClient.getStoriesForTask(task_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
 
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(errorResponse),
-            },
-          ],
-        };
+        case "asana_update_task": {
+          const { task_id, ...taskData } = args;
+          try {
+            const response = await asanaClient.updateTask(task_id, taskData);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          } catch (error) {
+            // When error occurs and html_notes was provided, validate it
+            if (taskData.html_notes && error instanceof Error && error.message.includes('400')) {
+              const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
+              if (xmlValidationErrors.length > 0) {
+                // Provide detailed validation errors to help the user
+                return {
+                  content: [{
+                    type: "text",
+                    text: JSON.stringify({
+                      error: error instanceof Error ? error.message : String(error),
+                      validation_errors: xmlValidationErrors,
+                      message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
+                    })
+                  }],
+                };
+              } else {
+                // HTML is valid, something else caused the error
+                return {
+                  content: [{
+                    type: "text",
+                    text: JSON.stringify({
+                      error: error instanceof Error ? error.message : String(error),
+                      html_notes_validation: "The HTML notes format is valid. The error must be related to something else."
+                    })
+                  }],
+                };
+              }
+            }
+            throw error; // re-throw to be caught by the outer try/catch
+          }
+        }
+
+        case "asana_get_project": {
+          const { project_id, ...opts } = args;
+          const response = await asanaClient.getProject(project_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_project_task_counts": {
+          const { project_id, ...opts } = args;
+          const response = await asanaClient.getProjectTaskCounts(project_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_project_status": {
+          const { project_status_gid, ...opts } = args;
+          const response = await asanaClient.getProjectStatus(project_status_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_project_statuses": {
+          const { project_gid, ...opts } = args;
+          const response = await asanaClient.getProjectStatusesForProject(project_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_create_project_status": {
+          const { project_gid, ...statusData } = args;
+          const response = await asanaClient.createProjectStatus(project_gid, statusData);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_delete_project_status": {
+          const { project_status_gid } = args;
+          const response = await asanaClient.deleteProjectStatus(project_status_gid);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_project_sections": {
+          const { project_id, ...opts } = args;
+          const response = await asanaClient.getProjectSections(project_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_create_task_story": {
+          const { task_id, text, html_text, ...opts } = args;
+
+          try {
+            // Validate if html_text is provided
+            if (html_text) {
+              const xmlValidationErrors = validateAsanaXml(html_text);
+              if (xmlValidationErrors.length > 0) {
+                return {
+                  content: [{
+                    type: "text",
+                    text: JSON.stringify({
+                      error: "HTML validation failed",
+                      validation_errors: xmlValidationErrors,
+                      message: "The HTML text contains invalid XML formatting. Please check the validation errors above."
+                    })
+                  }],
+                };
+              }
+            }
+
+            const response = await asanaClient.createTaskStory(task_id, text, opts, html_text);
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          } catch (error) {
+            // When error occurs and html_text was provided, help troubleshoot
+            if (html_text && error instanceof Error && error.message.includes('400')) {
+              return {
+                content: [{
+                  type: "text",
+                  text: JSON.stringify({
+                    error: error instanceof Error ? error.message : String(error),
+                    html_text_validation: "The HTML format is valid. The error must be related to something else in the API request."
+                  })
+                }],
+              };
+            }
+            throw error; // re-throw to be caught by the outer try/catch
+          }
+        }
+
+        case "asana_add_task_dependencies": {
+          const { task_id, dependencies } = args;
+          const response = await asanaClient.addTaskDependencies(task_id, dependencies);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_add_task_dependents": {
+          const { task_id, dependents } = args;
+          const response = await asanaClient.addTaskDependents(task_id, dependents);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_create_subtask": {
+          const { parent_task_id, opt_fields, ...taskData } = args;
+
+          try {
+            // Validate html_notes if provided
+            if (taskData.html_notes) {
+              const xmlValidationErrors = validateAsanaXml(taskData.html_notes);
+              if (xmlValidationErrors.length > 0) {
+                return {
+                  content: [{
+                    type: "text",
+                    text: JSON.stringify({
+                      error: "HTML validation failed",
+                      validation_errors: xmlValidationErrors,
+                      message: "The HTML notes contain invalid XML formatting. Please check the validation errors above."
+                    })
+                  }],
+                };
+              }
+            }
+
+            const response = await asanaClient.createSubtask(parent_task_id, taskData, { opt_fields });
+            return {
+              content: [{ type: "text", text: JSON.stringify(response) }],
+            };
+          } catch (error) {
+            // When error occurs and html_notes was provided, help troubleshoot
+            if (taskData.html_notes && error instanceof Error && error.message.includes('400')) {
+              return {
+                content: [{
+                  type: "text",
+                  text: JSON.stringify({
+                    error: error instanceof Error ? error.message : String(error),
+                    html_notes_validation: "The HTML notes format is valid. The error must be related to something else."
+                  })
+                }],
+              };
+            }
+            throw error; // re-throw to be caught by the outer try/catch
+          }
+        }
+
+        case "asana_get_multiple_tasks_by_gid": {
+          const { task_ids, ...opts } = args;
+          // Handle both array and string input
+          const taskIdList = Array.isArray(task_ids)
+            ? task_ids
+            : task_ids.split(',').map((id: string) => id.trim()).filter((id: string) => id.length > 0);
+          const response = await asanaClient.getMultipleTasksByGid(taskIdList, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_set_parent_for_task": {
+          let { data, task_id, opts } = args;
+          if (typeof data == "string") {
+            data = JSON.parse(data);
+          }
+          if (typeof opts == "string") {
+            opts = JSON.parse(opts);
+          }
+          const response = await asanaClient.setParentForTask(data, task_id, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_tasks_for_tag": {
+          const { tag_gid, ...opts } = args;
+          const response = await asanaClient.getTasksForTag(tag_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_tags_for_workspace": {
+          const { workspace_gid, ...opts } = args;
+          const response = await asanaClient.getTagsForWorkspace(workspace_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        default:
+          throw new Error(`Unknown tool: ${request.params.name}`);
       }
-    };
+    } catch (error) {
+      console.error("Error executing tool:", error);
+
+      // Default error response
+      const errorResponse = {
+        error: error instanceof Error ? error.message : String(error),
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(errorResponse),
+          },
+        ],
+      };
+    }
+  };
 }


### PR DESCRIPTION
# Add read-only mode

This PR implements a read-only mode as requested in #13. When enabled via the `READ_ONLY_MODE` environment variable, the server will only allow operations that read data from Asana, preventing any accidental modifications to workspaces, projects or tasks.

## Why?

Users who are new to MCP or who want to explore the Asana integration safely have expressed the need for a way to prevent accidental modifications to their Asana workspace. This is particularly useful for:
- Testing and exploring the MCP server capabilities
- Learning how to use the MCP server with Asana
- Running in production with restricted permissions

## Implementation details

The implementation follows security best practices with a "deny by default" approach:

1. Tools filtering:
   ```typescript
   const READ_ONLY_TOOLS = [
     'asana_list_workspaces',
     'asana_search_projects',
     'asana_search_tasks',
     // ...
   ];
   ```

2. Prompts filtering:
   ```typescript
   const READ_ONLY_PROMPTS = [
     'task-summary',
     'task-completeness'
   ];
   ```

3. Double safety mechanism:
   - Filter available tools/prompts when listing them
   - Additional check in handlers to block write operations

4. Resources are already read-only by default (list/read operations only)

## Testing

To test this change:
1. Set `READ_ONLY_MODE=true`
2. Verify that only read operations are available when listing tools and prompts
3. Verify that attempting to call a write operation directly results in an error
4. Verify that read operations work normally
5. Verify that the `create-task` prompt is not available
6. Set `READ_ONLY_MODE=false` and verify all operations are available again

## Documentation

The README has been updated with a new "Environment Variables" section that documents both the required `ASANA_ACCESS_TOKEN` and the new optional `READ_ONLY_MODE`, including details about which operations are disabled in read-only mode.

Fixes #13 
