### PR TITLE
fix(api): Map underscore params to dot-notation for task search

### DIFF
--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -1,4 +1,4 @@
-import Asana from 'asana';
+import Asana from "asana";
 
 export class AsanaClientWrapper {
   private workspaces: any;
@@ -11,7 +11,7 @@ export class AsanaClientWrapper {
 
   constructor(token: string) {
     const client = Asana.ApiClient.instance;
-    client.authentications['token'].accessToken = token;
+    client.authentications["token"].accessToken = token;
 
     // Initialize API instances
     this.workspaces = new Asana.WorkspacesApi();
@@ -28,12 +28,17 @@ export class AsanaClientWrapper {
     return response.data;
   }
 
-  async searchProjects(workspace: string, namePattern: string, archived: boolean = false, opts: any = {}) {
+  async searchProjects(
+    workspace: string,
+    namePattern: string,
+    archived: boolean = false,
+    opts: any = {}
+  ) {
     const response = await this.projects.getProjectsForWorkspace(workspace, {
       archived,
-      ...opts
+      ...opts,
     });
-    const pattern = new RegExp(namePattern, 'i');
+    const pattern = new RegExp(namePattern, "i");
     return response.data.filter((project: any) => pattern.test(project.name));
   }
 
@@ -55,17 +60,68 @@ export class AsanaClientWrapper {
 
     // Build search parameters
     const searchParams: any = {
-      ...otherOpts // Include any additional filter parameters
+      ...otherOpts, // Include any additional filter parameters
     };
+
+    // FIX: Manually translate parameter names from underscore to dot notation
+    const keyMappings: { [key: string]: string } = {
+      portfolios_any: "portfolios.any",
+      assignee_any: "assignee.any",
+      assignee_not: "assignee.not",
+      projects_any: "projects.any",
+      projects_not: "projects.not",
+      projects_all: "projects.all",
+      sections_any: "sections.any",
+      sections_not: "sections.not",
+      sections_all: "sections.all",
+      tags_any: "tags.any",
+      tags_not: "tags.not",
+      tags_all: "tags.all",
+      teams_any: "teams.any",
+      followers_any: "followers.any",
+      followers_not: "followers.not",
+      created_by_any: "created_by.any",
+      created_by_not: "created_by.not",
+      assigned_by_any: "assigned_by.any",
+      assigned_by_not: "assigned_by.not",
+      liked_by_not: "liked_by.not",
+      commented_on_by_not: "commented_on_by.not",
+      due_on_before: "due_on.before",
+      due_on_after: "due_on.after",
+      due_at_before: "due_at.before",
+      due_at_after: "due_at.after",
+      start_on_before: "start_on.before",
+      start_on_after: "start_on.after",
+      created_on_before: "created_on.before",
+      created_on_after: "created_on.after",
+      created_at_before: "created_at.before",
+      created_at_after: "created_at.after",
+      completed_on_before: "completed_on.before",
+      completed_on_after: "completed_on.after",
+      completed_at_before: "completed_at.before",
+      completed_at_after: "completed_at.after",
+      modified_on_before: "modified_on.before",
+      modified_on_after: "modified_on.after",
+      modified_at_before: "modified_at.before",
+      modified_at_after: "modified_at.after",
+    };
+
+    for (const [oldKey, newKey] of Object.entries(keyMappings)) {
+      if (searchParams[oldKey] !== undefined) {
+        searchParams[newKey] = searchParams[oldKey];
+        delete searchParams[oldKey];
+      }
+    }
 
     // Handle custom fields if provided
     if (searchOpts.custom_fields) {
-      if ( typeof searchOpts.custom_fields == "string" ) {
+      if (typeof searchOpts.custom_fields == "string") {
         try {
-          searchOpts.custom_fields = JSON.parse( searchOpts.custom_fields );
-        } catch ( err ) {
+          searchOpts.custom_fields = JSON.parse(searchOpts.custom_fields);
+        } catch (err) {
           if (err instanceof Error) {
-            err.message = "custom_fields must be a JSON object : " + err.message;
+            err.message =
+              "custom_fields must be a JSON object : " + err.message;
           }
           throw err;
         }
@@ -81,14 +137,19 @@ export class AsanaClientWrapper {
     if (resource_subtype) searchParams.resource_subtype = resource_subtype;
     if (completed !== undefined) searchParams.completed = completed;
     if (is_subtask !== undefined) searchParams.is_subtask = is_subtask;
-    if (has_attachment !== undefined) searchParams.has_attachment = has_attachment;
+    if (has_attachment !== undefined)
+      searchParams.has_attachment = has_attachment;
     if (is_blocked !== undefined) searchParams.is_blocked = is_blocked;
     if (is_blocking !== undefined) searchParams.is_blocking = is_blocking;
     if (sort_by) searchParams.sort_by = sort_by;
-    if (sort_ascending !== undefined) searchParams.sort_ascending = sort_ascending;
+    if (sort_ascending !== undefined)
+      searchParams.sort_ascending = sort_ascending;
     if (opt_fields) searchParams.opt_fields = opt_fields;
 
-    const response = await this.tasks.searchTasksForWorkspace(workspace, searchParams);
+    const response = await this.tasks.searchTasksForWorkspace(
+      workspace,
+      searchParams
+    );
 
     // Transform the response to simplify custom fields if present
     const transformedData = response.data.map((task: any) => {
@@ -101,13 +162,13 @@ export class AsanaClientWrapper {
           let value = field.display_value;
 
           // For enum fields with a value, include the enum option GID
-          if (field.type === 'enum' && field.enum_value) {
+          if (field.type === "enum" && field.enum_value) {
             value = `${field.display_value} (${field.enum_value.gid})`;
           }
 
           acc[key] = value;
           return acc;
-        }, {})
+        }, {}),
       };
     });
 
@@ -131,10 +192,10 @@ export class AsanaClientWrapper {
         ...data,
         projects,
         // Handle resource_subtype if provided
-        resource_subtype: data.resource_subtype || 'default_task',
+        resource_subtype: data.resource_subtype || "default_task",
         // Handle custom_fields if provided
-        custom_fields: data.custom_fields || {}
-      }
+        custom_fields: data.custom_fields || {},
+      },
     };
     const response = await this.tasks.createTask(taskData);
     return response.data;
@@ -152,8 +213,8 @@ export class AsanaClientWrapper {
         // Handle resource_subtype if provided
         resource_subtype: data.resource_subtype || undefined,
         // Handle custom_fields if provided
-        custom_fields: data.custom_fields || undefined
-      }
+        custom_fields: data.custom_fields || undefined,
+      },
     };
     const opts = {};
     const response = await this.tasks.updateTask(body, taskId, opts);
@@ -171,13 +232,22 @@ export class AsanaClientWrapper {
     try {
       const options = {
         limit: 100,
-        opt_fields: opts.opt_fields || "custom_field,custom_field.name,custom_field.gid,custom_field.resource_type,custom_field.type,custom_field.description,custom_field.enum_options,custom_field.enum_options.name,custom_field.enum_options.gid,custom_field.enum_options.enabled"
+        opt_fields:
+          opts.opt_fields ||
+          "custom_field,custom_field.name,custom_field.gid,custom_field.resource_type,custom_field.type,custom_field.description,custom_field.enum_options,custom_field.enum_options.name,custom_field.enum_options.gid,custom_field.enum_options.enabled",
       };
 
-      const response = await this.customFieldSettings.getCustomFieldSettingsForProject(projectId, options);
+      const response =
+        await this.customFieldSettings.getCustomFieldSettingsForProject(
+          projectId,
+          options
+        );
       return response.data;
     } catch (error) {
-      console.error(`Error fetching custom field settings for project ${projectId}:`, error);
+      console.error(
+        `Error fetching custom field settings for project ${projectId}:`,
+        error
+      );
       return [];
     }
   }
@@ -185,7 +255,10 @@ export class AsanaClientWrapper {
   async getProjectTaskCounts(projectId: string, opts: any = {}) {
     // Only include opts if opt_fields was actually provided
     const options = opts.opt_fields ? opts : {};
-    const response = await this.projects.getTaskCountsForProject(projectId, options);
+    const response = await this.projects.getTaskCountsForProject(
+      projectId,
+      options
+    );
     return response.data;
   }
 
@@ -197,7 +270,12 @@ export class AsanaClientWrapper {
     return response.data;
   }
 
-  async createTaskStory(taskId: string, text: string | null = null, opts: any = {}, html_text: string | null = null) {
+  async createTaskStory(
+    taskId: string,
+    text: string | null = null,
+    opts: any = {},
+    html_text: string | null = null
+  ) {
     const options = opts.opt_fields ? opts : {};
     const data: any = {};
 
@@ -210,15 +288,19 @@ export class AsanaClientWrapper {
     }
 
     const body = { data };
-    const response = await this.stories.createStoryForTask(body, taskId, options);
+    const response = await this.stories.createStoryForTask(
+      body,
+      taskId,
+      options
+    );
     return response.data;
   }
 
   async addTaskDependencies(taskId: string, dependencies: string[]) {
     const body = {
       data: {
-        dependencies: dependencies
-      }
+        dependencies: dependencies,
+      },
     };
     const response = await this.tasks.addDependenciesForTask(body, taskId);
     return response.data;
@@ -227,8 +309,8 @@ export class AsanaClientWrapper {
   async addTaskDependents(taskId: string, dependents: string[]) {
     const body = {
       data: {
-        dependents: dependents
-      }
+        dependents: dependents,
+      },
     };
     const response = await this.tasks.addDependentsForTask(body, taskId);
     return response.data;
@@ -237,10 +319,14 @@ export class AsanaClientWrapper {
   async createSubtask(parentTaskId: string, data: any, opts: any = {}) {
     const taskData = {
       data: {
-        ...data
-      }
+        ...data,
+      },
     };
-    const response = await this.tasks.createSubtaskForTask(taskData, parentTaskId, opts);
+    const response = await this.tasks.createSubtaskForTask(
+      taskData,
+      parentTaskId,
+      opts
+    );
     return response.data;
   }
 
@@ -250,18 +336,27 @@ export class AsanaClientWrapper {
   }
 
   async getProjectStatus(statusId: string, opts: any = {}) {
-    const response = await this.projectStatuses.getProjectStatus(statusId, opts);
+    const response = await this.projectStatuses.getProjectStatus(
+      statusId,
+      opts
+    );
     return response.data;
   }
 
   async getProjectStatusesForProject(projectId: string, opts: any = {}) {
-    const response = await this.projectStatuses.getProjectStatusesForProject(projectId, opts);
+    const response = await this.projectStatuses.getProjectStatusesForProject(
+      projectId,
+      opts
+    );
     return response.data;
   }
 
   async createProjectStatus(projectId: string, data: any) {
     const body = { data };
-    const response = await this.projectStatuses.createProjectStatusForProject(body, projectId);
+    const response = await this.projectStatuses.createProjectStatusForProject(
+      body,
+      projectId
+    );
     return response.data;
   }
 
@@ -277,7 +372,7 @@ export class AsanaClientWrapper {
 
     // Use Promise.all to fetch tasks in parallel
     const tasks = await Promise.all(
-      taskIds.map(taskId => this.getTask(taskId, opts))
+      taskIds.map((taskId) => this.getTask(taskId, opts))
     );
 
     return tasks;


### PR DESCRIPTION
The Asana API's `searchTasksForWorkspace` endpoint was silently ignoring filter parameters like `sections_all`, `projects_any`, and `assignee_any`.

This was due to a mismatch between the MCP tool's underscore-based parameter names (e.g., `sections_all`) and the API's required dot-notation (e.g., `sections.all`). The client wrapper did not translate these names, causing the Asana SDK to discard them.

This commit introduces a key mapping layer within the `AsanaClientWrapper` to translate all relevant search parameters into the correct format before making the API call. This ensures that all search filters are correctly applied, resolving the issue of overly broad search results.

Fixes #25