### PR TITLE
feat: Add tools to add/remove tasks from projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - HTML validation for task creation and update: validate html_notes when API returns 400 errors
 - HTML support for task comments: added html_text parameter to createTaskStory
+- Project management tools: `asana_add_project_to_task` and `asana_remove_project_from_task` for moving tasks between projects
+- Support for positioning tasks when adding to projects (section, insert_after, insert_before)
 
 ### Changed
 - Improved error handling for HTML content validation

--- a/README.md
+++ b/README.md
@@ -232,6 +232,24 @@ Another example:
         * offset (string): Offset token. An offset to the next page returned by the API.
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of tags in the workspace
+23. `asana_add_project_to_task`
+    * Add an existing task to a project
+    * Required input:
+        * task_id (string): The task ID to add to the project
+        * project_id (string): The project ID to add the task to
+    * Optional input:
+        * section (string): The section ID to add the task to within the project
+        * insert_after (string): A task ID to insert this task after. At most one of insert_before, insert_after, or section should be specified.
+        * insert_before (string): A task ID to insert this task before. At most one of insert_before, insert_after, or section should be specified.
+    * Returns: Updated task information
+    * Notes: If no positioning arguments are given, the task will be added to the end of the project
+24. `asana_remove_project_from_task`
+    * Remove a task from a project
+    * Required input:
+        * task_id (string): The task ID to remove from the project
+        * project_id (string): The project ID to remove the task from
+    * Returns: Updated task information
+    * Notes: The task will still exist in the system, but it will not be in the project anymore
 
 ## Prompts
 

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -292,4 +292,36 @@ export class AsanaClientWrapper {
     const response = await this.tags.getTagsForWorkspace(workspace_gid, opts);
     return response.data;
   }
+
+  async addProjectToTask(taskId: string, projectId: string, data: any = {}) {
+    const body: any = {
+      data: {
+        project: projectId
+      }
+    };
+
+    // Add optional positioning parameters if provided
+    if (data.section) {
+      body.data.section = data.section;
+    }
+    if (data.insert_after) {
+      body.data.insert_after = data.insert_after;
+    }
+    if (data.insert_before) {
+      body.data.insert_before = data.insert_before;
+    }
+
+    const response = await this.tasks.addProjectForTask(body, taskId);
+    return response.data;
+  }
+
+  async removeProjectFromTask(taskId: string, projectId: string) {
+    const body = {
+      data: {
+        project: projectId
+      }
+    };
+    const response = await this.tasks.removeProjectForTask(body, taskId);
+    return response.data;
+  }
 }

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -21,7 +21,9 @@ import {
   createTaskTool,
   updateTaskTool,
   createSubtaskTool,
-  getMultipleTasksByGidTool
+  getMultipleTasksByGidTool,
+  addProjectToTaskTool,
+  removeProjectFromTaskTool
 } from './tools/task-tools.js';
 import { getTasksForTagTool, getTagsForWorkspaceTool } from './tools/tag-tools.js';
 import {
@@ -58,6 +60,8 @@ const all_tools: Tool[] = [
   setParentForTaskTool,
   getTasksForTagTool,
   getTagsForWorkspaceTool,
+  addProjectToTaskTool,
+  removeProjectFromTaskTool,
 ];
 
 // List of tools that only read Asana state
@@ -418,6 +422,27 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
         case "asana_get_tags_for_workspace": {
           const { workspace_gid, ...opts } = args;
           const response = await asanaClient.getTagsForWorkspace(workspace_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_add_project_to_task": {
+          const { task_id, project_id, section, insert_after, insert_before } = args;
+          const data: any = {};
+          if (section) data.section = section;
+          if (insert_after) data.insert_after = insert_after;
+          if (insert_before) data.insert_before = insert_before;
+
+          const response = await asanaClient.addProjectToTask(task_id, project_id, data);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_remove_project_from_task": {
+          const { task_id, project_id } = args;
+          const response = await asanaClient.removeProjectFromTask(task_id, project_id);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -434,3 +434,53 @@ export const getMultipleTasksByGidTool: Tool = {
   }
 };
 
+export const addProjectToTaskTool: Tool = {
+  name: "asana_add_project_to_task",
+  description: "Add an existing task to a project. If no positioning arguments are given, the task will be added to the end of the project.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description: "The task ID to add to the project"
+      },
+      project_id: {
+        type: "string",
+        description: "The project ID to add the task to"
+      },
+      section: {
+        type: "string",
+        description: "Optional: The section ID to add the task to within the project"
+      },
+      insert_after: {
+        type: "string",
+        description: "Optional: A task ID to insert this task after. At most one of insert_before, insert_after, or section should be specified."
+      },
+      insert_before: {
+        type: "string",
+        description: "Optional: A task ID to insert this task before. At most one of insert_before, insert_after, or section should be specified."
+      }
+    },
+    required: ["task_id", "project_id"]
+  }
+};
+
+export const removeProjectFromTaskTool: Tool = {
+  name: "asana_remove_project_from_task",
+  description: "Remove a task from a project. The task will still exist in the system, but it will not be in the project anymore.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description: "The task ID to remove from the project"
+      },
+      project_id: {
+        type: "string",
+        description: "The project ID to remove the task from"
+      }
+    },
+    required: ["task_id", "project_id"]
+  }
+};
+


### PR DESCRIPTION
## Summary

This PR adds two new tools for managing task-project relationships:
- `asana_add_project_to_task` - Add an existing task to a project
- `asana_remove_project_from_task` - Remove a task from a project

## Motivation

Closes #22 

Currently there's no way to add a task to multiple projects or move tasks between projects using the MCP server. These tools enable common workflows like:
- Adding a task to a project board after creation
- Moving tasks between project phases
- Organizing tasks across multiple projects

## Changes

### New Tools

**asana_add_project_to_task**
- Adds a task to a project with optional positioning
- Supports `section`, `insert_after`, and `insert_before` parameters
- If no positioning is specified, task is added to the end of the project

**asana_remove_project_from_task**  
- Removes a task from a project (task still exists, just unlinked)

### Files Changed
- `src/tools/task-tools.ts` - Tool definitions
- `src/tool-handler.ts` - Handler implementation
- `src/asana-client-wrapper.ts` - API client methods
- `README.md` - Documentation for new tools
- `CHANGELOG.md` - Release notes

## Testing

Tested locally using the MCP Inspector (`npm run inspector`) with real Asana workspace:
- ✅ Add task to project (basic)
- ✅ Add task to specific section
- ✅ Add task with insert_after positioning
- ✅ Remove task from project
- ✅ Verified task still exists after removal

## Checklist
- [x] Code follows existing conventions (TypeScript, SDK v3)
- [x] Build passes (`npm run build`)
- [x] README updated with new tool documentation
- [x] CHANGELOG updated