### PR TITLE
feat: Add task follower tools (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,23 @@ Another example:
         * task_id (string): The task ID to add dependents to
         * dependents (array of strings): Array of task IDs that depend on this task
     * Returns: Updated task dependents
-14. `asana_create_subtask`
+14. `asana_add_task_followers`
+    * Add followers to a task
+    * Required input:
+        * task_id (string): The task ID to add followers to
+        * followers (array of strings): Array of user GIDs to add as followers of the task
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Updated task information
+15. `asana_remove_task_followers`
+    * Remove followers from a task
+    * Required input:
+        * task_id (string): The task ID to remove followers from
+        * followers (array of strings): Array of user GIDs to remove as followers of the task
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Updated task information
+16. `asana_create_subtask`
     * Create a new subtask for an existing task
     * Required input:
         * parent_task_id (string): The parent task ID to create the subtask under
@@ -166,21 +182,21 @@ Another example:
         * assignee (string): Assignee (can be 'me' or a user ID)
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Created subtask information
-15. `asana_get_multiple_tasks_by_gid`
+17. `asana_get_multiple_tasks_by_gid`
     * Get detailed information about multiple tasks by their GIDs (maximum 25 tasks)
     * Required input:
         * task_ids (array of strings or comma-separated string): Task GIDs to retrieve (max 25)
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of detailed task information
-16. `asana_get_project_status`
+18. `asana_get_project_status`
     * Get a project status update
     * Required input:
         * project_status_gid (string): The project status GID to retrieve
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Project status information
-17. `asana_get_project_statuses`
+19. `asana_get_project_statuses`
     * Get all status updates for a project
     * Required input:
         * project_gid (string): The project GID to get statuses for
@@ -189,7 +205,7 @@ Another example:
         * offset (string): Pagination offset token
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of project status updates
-18. `asana_create_project_status`
+20. `asana_create_project_status`
     * Create a new status update for a project
     * Required input:
         * project_gid (string): The project GID to create the status for
@@ -200,12 +216,12 @@ Another example:
         * html_text (string): HTML formatted text for the status update
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Created project status information
-19. `asana_delete_project_status`
+21. `asana_delete_project_status`
     * Delete a project status update
     * Required input:
         * project_status_gid (string): The project status GID to delete
     * Returns: Deletion confirmation
-20. `asana_set_parent_for_task`
+22. `asana_set_parent_for_task`
     * Set the parent of a task and position the subtask within the other subtasks of that parent
     * Required input:
         * task_id (string): The task ID to operate on
@@ -216,14 +232,14 @@ Another example:
         * insert_before (string): A subtask of the parent to insert the task before, or null to insert at the end of the list
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Updated task information
-21. `asana_get_tag`
+23. `asana_get_tag`
     * Get detailed information about a specific tag
     * Required input:
         * tag_gid (string): Globally unique identifier for the tag
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Detailed tag information
-22. `asana_get_tags_for_task`
+24. `asana_get_tags_for_task`
     * Get a task's tags
     * Required input:
         * task_gid (string): The task to operate on
@@ -232,7 +248,7 @@ Another example:
         * offset (string): Offset token. An offset to the next page returned by the API.
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of tags associated with the task
-23. `asana_get_tasks_for_tag`
+25. `asana_get_tasks_for_tag`
     * Get tasks for a specific tag
     * Required input:
         * tag_gid (string): The tag GID to retrieve tasks for
@@ -242,7 +258,7 @@ Another example:
         * limit (integer): The number of objects to return per page. The value must be between 1 and 100.
         * offset (string): An offset to the next page returned by the API.
     * Returns: List of tasks for the specified tag
-24. `asana_get_tags_for_workspace`
+26. `asana_get_tags_for_workspace`
     * Get tags in a workspace
     * Required input:
         * workspace_gid (string): Globally unique identifier for the workspace or organization
@@ -251,7 +267,7 @@ Another example:
         * offset (string): Offset token. An offset to the next page returned by the API.
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: List of tags in the workspace
-25. `asana_update_tag`
+27. `asana_update_tag`
     * Update an existing tag
     * Required input:
         * tag_gid (string): Globally unique identifier for the tag
@@ -261,12 +277,12 @@ Another example:
         * notes (string): Notes about the tag
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Updated tag information
-26. `asana_delete_tag`
+28. `asana_delete_tag`
     * Delete a tag
     * Required input:
         * tag_gid (string): Globally unique identifier for the tag
     * Returns: Deletion confirmation
-27. `asana_create_tag_for_workspace`
+29. `asana_create_tag_for_workspace`
     * Create a new tag in a workspace
     * Required input:
         * workspace_gid (string): Globally unique identifier for the workspace or organization
@@ -276,19 +292,19 @@ Another example:
         * notes (string): Notes about the tag
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Created tag information
-28. `asana_add_tag_to_task`
+30. `asana_add_tag_to_task`
     * Add a tag to a task
     * Required input:
         * task_gid (string): The task GID to add the tag to
         * tag_gid (string): The tag GID to add to the task
     * Returns: Success response
-29. `asana_remove_tag_from_task`
+31. `asana_remove_tag_from_task`
     * Remove a tag from a task
     * Required input:
         * task_gid (string): The task GID to remove the tag from
         * tag_gid (string): The tag GID to remove from the task
     * Returns: Success response
-30. `asana_add_project_to_task`
+32. `asana_add_project_to_task`
     * Add an existing task to a project
     * Required input:
         * task_id (string): The task ID to add to the project
@@ -299,20 +315,20 @@ Another example:
         * insert_before (string): A task ID to insert this task before. At most one of insert_before, insert_after, or section should be specified.
     * Returns: Success message confirming the task was added to the project
     * Notes: If no positioning arguments are given, the task will be added to the end of the project
-31. `asana_remove_project_from_task`
+33. `asana_remove_project_from_task`
     * Remove a task from a project
     * Required input:
         * task_id (string): The task ID to remove from the project
         * project_id (string): The project ID to remove the task from
     * Returns: Success message confirming the task was removed from the project
     * Notes: The task will still exist in the system, but it will not be in the project anymore
-32. `asana_delete_task`
+34. `asana_delete_task`
     * Delete a task permanently
     * Required input:
         * task_id (string): The task ID to delete
     * Returns: Success message confirming the task was deleted
     * Notes: This action cannot be undone. The task will be permanently removed.
-33. `asana_create_project`
+35. `asana_create_project`
     * Create a new project in a workspace or team
     * Required input:
         * workspace (string): The workspace GID to create the project in
@@ -325,7 +341,7 @@ Another example:
         * default_view (string): Default view (list, board, calendar, timeline)
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: The created project object
-34. `asana_update_project`
+36. `asana_update_project`
     * Update a project's details (name, description, etc.)
     * Required input:
         * project_id (string): The project GID to update
@@ -337,7 +353,7 @@ Another example:
         * privacy_setting (string): Privacy setting (public_to_workspace, private_to_team, private)
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Updated project information
-35. `asana_create_section`
+37. `asana_create_section`
     * Create a new section in a project
     * Required input:
         * project_id (string): The project GID to create the section in
@@ -345,7 +361,7 @@ Another example:
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Created section information
-36. `asana_update_section`
+38. `asana_update_section`
     * Update a section (rename it)
     * Required input:
         * section_id (string): The section GID to update
@@ -353,12 +369,12 @@ Another example:
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include
     * Returns: Updated section information
-37. `asana_delete_section`
+39. `asana_delete_section`
     * Delete a section from a project
     * Required input:
         * section_id (string): The section GID to delete
     * Returns: Deletion confirmation
-38. `asana_add_task_to_section`
+40. `asana_add_task_to_section`
     * Move a task to a section within its project
     * Required input:
         * section_id (string): The section GID to add the task to
@@ -367,14 +383,14 @@ Another example:
         * insert_before (string): A task GID to insert the task before
         * insert_after (string): A task GID to insert the task after
     * Returns: Success confirmation
-39. `asana_get_subtasks`
+41. `asana_get_subtasks`
     * Get all subtasks of a given task. Returns a compact representation of each subtask.
     * Required input:
         * task_gid (string): The GID of the parent task
     * Optional input:
         * opt_fields (string): Comma-separated list of optional fields to include (e.g. 'name,completed,assignee,due_on')
     * Returns: Array of subtask objects
-40. `asana_get_tasks_for_project`
+42. `asana_get_tasks_for_project`
     * Get all tasks in a project. Use this instead of search_tasks when you need to list tasks in a specific project. Works on free Asana plans (unlike search_tasks which requires premium). Supports pagination and optional field selection.
     * Required input:
         * project_id (string): The project GID to get tasks for
@@ -383,7 +399,7 @@ Another example:
         * limit (number): Results per page (1-100)
         * offset (string): Pagination offset token from a previous response
     * Returns: Array of task objects
-41. `asana_get_my_tasks`
+43. `asana_get_my_tasks`
     * Get tasks from the authenticated user's 'My Tasks' list in a workspace
     * Required input:
         * workspace (string): The workspace GID to get My Tasks from

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Another example:
         * html_notes (string): HTML-like formatted description of the task (subset of HTML tags supported)
         * due_on (string): New due date in YYYY-MM-DD format
         * assignee (string): New assignee (can be 'me' or a user ID)
-        * followers (array): Array of user IDs to add as followers
         * parent (string): The parent task ID to move this task under
         * completed (boolean): Mark task as completed or not
         * resource_subtype (string): The type of the task (default_task or milestone)

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -315,6 +315,28 @@ export class AsanaClientWrapper {
     return response.data;
   }
 
+  async addTaskFollowers(taskId: string, followers: string[], opts: any = {}) {
+    const body = {
+      data: {
+        followers: followers
+      }
+    };
+    const options = opts.opt_fields ? opts : {};
+    const response = await this.tasks.addFollowersForTask(body, taskId, options);
+    return response.data;
+  }
+
+  async removeTaskFollowers(taskId: string, followers: string[], opts: any = {}) {
+    const body = {
+      data: {
+        followers: followers
+      }
+    };
+    const options = opts.opt_fields ? opts : {};
+    const response = await this.tasks.removeFollowerForTask(body, taskId, options);
+    return response.data;
+  }
+
   async getSubtasksForTask(taskId: string, opts: any = {}) {
     const response = await this.tasks.getSubtasksForTask(taskId, opts);
     return response.data;

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -51,6 +51,8 @@ import {
 import {
   addTaskDependenciesTool,
   addTaskDependentsTool,
+  addTaskFollowersTool,
+  removeTaskFollowersTool,
   setParentForTaskTool
 } from './tools/task-relationship-tools.js';
 import {
@@ -76,6 +78,8 @@ const all_tools: Tool[] = [
   createTaskStoryTool,
   addTaskDependenciesTool,
   addTaskDependentsTool,
+  addTaskFollowersTool,
+  removeTaskFollowersTool,
   createSubtaskTool,
   getSubtasksForTaskTool,
   getMultipleTasksByGidTool,
@@ -420,6 +424,22 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
         case "asana_add_task_dependents": {
           const { task_id, dependents } = args;
           const response = await asanaClient.addTaskDependents(task_id, dependents);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_add_task_followers": {
+          const { task_id, followers, opt_fields } = args;
+          const response = await asanaClient.addTaskFollowers(task_id, followers, { opt_fields });
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_remove_task_followers": {
+          const { task_id, followers, opt_fields } = args;
+          const response = await asanaClient.removeTaskFollowers(task_id, followers, { opt_fields });
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };

--- a/src/tools/task-relationship-tools.ts
+++ b/src/tools/task-relationship-tools.ts
@@ -44,6 +44,58 @@ export const addTaskDependentsTool: Tool = {
   }
 };
 
+export const addTaskFollowersTool: Tool = {
+  name: "asana_add_task_followers",
+  description: "Add followers to a task",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description: "The task ID to add followers to"
+      },
+      followers: {
+        type: "array",
+        items: {
+          type: "string"
+        },
+        description: "Array of user GIDs to add as followers of the task"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["task_id", "followers"]
+  }
+};
+
+export const removeTaskFollowersTool: Tool = {
+  name: "asana_remove_task_followers",
+  description: "Remove followers from a task",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_id: {
+        type: "string",
+        description: "The task ID to remove followers from"
+      },
+      followers: {
+        type: "array",
+        items: {
+          type: "string"
+        },
+        description: "Array of user GIDs to remove as followers of the task"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["task_id", "followers"]
+  }
+};
+
 export const setParentForTaskTool: Tool = {
   name: "asana_set_parent_for_task",
   description: "Set the parent of a task and position the subtask within the other subtasks of that parent",

--- a/src/tools/task-tools.ts
+++ b/src/tools/task-tools.ts
@@ -374,13 +374,6 @@ export const updateTaskTool: Tool = {
         type: "string",
         description: "New assignee (can be 'me' or a user ID)"
       },
-      followers: {
-        type: "array",
-        items: {
-          type: "string"
-        },
-        description: "Array of user IDs to add as followers"
-      },
       parent: {
         type: "string",
         description: "The parent task ID to move this task under"


### PR DESCRIPTION
## Summary
- Adds `asana_add_task_followers` and `asana_remove_task_followers` tools, backed by Asana's dedicated `POST /tasks/{gid}/addFollowers` and `removeFollowers` endpoints
- Fixes the `Bad Request` that users hit when passing `followers` to `asana_update_task` — the Asana REST API does not support setting followers via the task update endpoint
- Both tools accept a `task_id`, a `followers` array of user GIDs, and an optional `opt_fields`

Closes #48.

## Test plan
- [x] Built cleanly with `npm run build`
- [x] Tools listed via MCP Inspector CLI (`mcp_list_tools`)
- [x] `asana_remove_task_followers` — removed a follower from a real task, verified follower list updated
- [x] `asana_add_task_followers` — added the follower back, verified follower list restored
- [x] `opt_fields` honored in the response shape
- [x] Invalid user GID returns a clean `Bad Request` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)