### PR TITLE
feat: Add task template instantiation tools (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `asana_get_task_templates` tool: list task templates within a project (#51)
+- New `asana_get_task_template` tool: fetch the full record for a single task template
+- New `asana_instantiate_task` tool: create a task from a task template; returns the Asana Job that handles the instantiation asynchronously
+- New `asana_get_job` tool: poll an Asana Job by GID, used to retrieve the resulting task GID after instantiation
+
 
 ## [1.8.0] - 2026-03-29
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,37 @@ Another example:
         * opt_fields (string): Comma-separated list of optional fields to include
         * completed_since (string): Only return tasks completed since this time (ISO 8601). Use 'now' to only return incomplete tasks.
     * Returns: List of tasks from the user's My Tasks list
+42. `asana_get_task_templates`
+    * List task templates in a project
+    * Required input:
+        * project (string): The project GID to filter task templates on
+    * Optional input:
+        * limit (number): Results per page (1-100)
+        * offset (string): Pagination offset token from a previous response
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: List of task templates
+43. `asana_get_task_template`
+    * Get the full record for a single task template by GID
+    * Required input:
+        * task_template_gid (string): The task template GID to retrieve
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Full task template record (including subtasks, custom fields, etc.)
+44. `asana_instantiate_task`
+    * Create a new task from a task template
+    * Required input:
+        * task_template_gid (string): The task template GID to instantiate from
+        * name (string): The name for the new task
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: An object containing a Job (not a Task). The Asana API processes instantiation asynchronously. Poll `asana_get_job` with the returned job GID until `status` is `succeeded`; the resulting task GID will then appear in the job's `new_task` field.
+45. `asana_get_job`
+    * Get the full record for an Asana Job by GID. Used to poll asynchronous operations such as task template instantiation.
+    * Required input:
+        * job_gid (string): The job GID to retrieve
+    * Optional input:
+        * opt_fields (string): Comma-separated list of optional fields to include
+    * Returns: Job record with `status` (one of `not_started`, `in_progress`, `succeeded`, `failed`) and, when applicable, the resulting resource (e.g. `new_task`).
 
 ## Prompts
 

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -10,6 +10,8 @@ export class AsanaClientWrapper {
   private customFieldSettings: any;
   private sections: any;
   private userTaskLists: any;
+  private taskTemplates: any;
+  private jobs: any;
 
   constructor(token: string) {
     const client = Asana.ApiClient.instance;
@@ -25,6 +27,8 @@ export class AsanaClientWrapper {
     this.customFieldSettings = new Asana.CustomFieldSettingsApi();
     this.sections = new Asana.SectionsApi();
     this.userTaskLists = new Asana.UserTaskListsApi();
+    this.taskTemplates = new Asana.TaskTemplatesApi();
+    this.jobs = new Asana.JobsApi();
   }
 
   async listWorkspaces(opts: any = {}) {
@@ -499,6 +503,32 @@ export class AsanaClientWrapper {
     const options = opts.opt_fields ? opts : {};
     const body = { data };
     const response = await this.projects.updateProject(body, projectId, options);
+    return response.data;
+  }
+
+  async getTaskTemplates(opts: any = {}) {
+    const response = await this.taskTemplates.getTaskTemplates(opts);
+    return response.data;
+  }
+
+  async getTaskTemplate(taskTemplateGid: string, opts: any = {}) {
+    const response = await this.taskTemplates.getTaskTemplate(taskTemplateGid, opts);
+    return response.data;
+  }
+
+  async instantiateTask(taskTemplateGid: string, name: string, opts: any = {}) {
+    // The Asana API expects { data: { name } } as the request body.
+    // The SDK accepts the body via opts.body and other parameters as query params.
+    const callOpts: any = {
+      body: { data: { name } }
+    };
+    if (opts.opt_fields) callOpts.opt_fields = opts.opt_fields;
+    const response = await this.taskTemplates.instantiateTask(taskTemplateGid, callOpts);
+    return response.data;
+  }
+
+  async getJob(jobGid: string, opts: any = {}) {
+    const response = await this.jobs.getJob(jobGid, opts);
     return response.data;
   }
 }

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -57,6 +57,14 @@ import {
   getStoriesForTaskTool,
   createTaskStoryTool
 } from './tools/story-tools.js';
+import {
+  getTaskTemplatesTool,
+  getTaskTemplateTool,
+  instantiateTaskTool
+} from './tools/task-template-tools.js';
+import {
+  getJobTool
+} from './tools/job-tools.js';
 
 // List of all available tools
 const all_tools: Tool[] = [
@@ -101,6 +109,10 @@ const all_tools: Tool[] = [
   deleteSectionTool,
   addTaskToSectionTool,
   updateProjectTool,
+  getTaskTemplatesTool,
+  getTaskTemplateTool,
+  instantiateTaskTool,
+  getJobTool,
 ];
 
 // List of tools that only read Asana state
@@ -122,7 +134,10 @@ const READ_ONLY_TOOLS = [
   'asana_get_tags_for_task',
   'asana_get_tasks_for_tag',
   'asana_get_tags_for_workspace',
-  'asana_get_subtasks'
+  'asana_get_subtasks',
+  'asana_get_task_templates',
+  'asana_get_task_template',
+  'asana_get_job'
 ];
 
 // Filter tools based on READ_ONLY_MODE
@@ -688,6 +703,43 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
             }
             throw error;
           }
+        }
+
+        case "asana_get_task_templates": {
+          const response = await asanaClient.getTaskTemplates(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_task_template": {
+          const { task_template_gid, ...opts } = args;
+          const response = await asanaClient.getTaskTemplate(task_template_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_instantiate_task": {
+          const { task_template_gid, name, opt_fields } = args;
+          const response = await asanaClient.instantiateTask(task_template_gid, name, { opt_fields });
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                job: response,
+                note: "Task instantiation is asynchronous. The response is a Job, not a Task. Poll asana_get_job with the job's GID until status is 'succeeded'; the resulting task GID will be available in the job's 'new_task' field."
+              })
+            }],
+          };
+        }
+
+        case "asana_get_job": {
+          const { job_gid, ...opts } = args;
+          const response = await asanaClient.getJob(job_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
         }
 
         default:

--- a/src/tools/job-tools.ts
+++ b/src/tools/job-tools.ts
@@ -1,0 +1,20 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const getJobTool: Tool = {
+  name: "asana_get_job",
+  description: "Get the full record for an Asana Job by GID. Used to poll asynchronous operations (e.g. task template instantiation). The Job's 'status' field will be 'not_started', 'in_progress', 'succeeded', or 'failed'. When succeeded, the resulting resource (e.g. 'new_task') will be populated.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      job_gid: {
+        type: "string",
+        description: "The job GID to retrieve"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["job_gid"]
+  }
+};

--- a/src/tools/task-template-tools.ts
+++ b/src/tools/task-template-tools.ts
@@ -1,0 +1,70 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const getTaskTemplatesTool: Tool = {
+  name: "asana_get_task_templates",
+  description: "List task templates filtered by project. The Asana API requires the 'project' parameter to scope the results.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      project: {
+        type: "string",
+        description: "The project GID to filter task templates on"
+      },
+      limit: {
+        type: "number",
+        description: "Results per page (1-100)"
+      },
+      offset: {
+        type: "string",
+        description: "Pagination offset token from a previous response"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["project"]
+  }
+};
+
+export const getTaskTemplateTool: Tool = {
+  name: "asana_get_task_template",
+  description: "Get the full record for a single task template by GID",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_template_gid: {
+        type: "string",
+        description: "The task template GID to retrieve"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["task_template_gid"]
+  }
+};
+
+export const instantiateTaskTool: Tool = {
+  name: "asana_instantiate_task",
+  description: "Instantiate a task from a task template. The Asana API processes this asynchronously: the response is a Job, not a Task. To retrieve the resulting task GID, poll asana_get_job until the job's status is 'succeeded' (the new task GID will then appear in the job's 'new_task' field).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      task_template_gid: {
+        type: "string",
+        description: "The task template GID to instantiate from"
+      },
+      name: {
+        type: "string",
+        description: "The name for the new task (overrides any default name in the template)"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include in the Job response"
+      }
+    },
+    required: ["task_template_gid", "name"]
+  }
+};


### PR DESCRIPTION
## Summary

Adds four new tools to support creating tasks from task templates, closing #51:

- `asana_get_task_templates` (read-only): list task templates filtered by project
- `asana_get_task_template` (read-only): fetch the full record for a single template
- `asana_instantiate_task` (write): create a task from a template; returns an Asana Job
- `asana_get_job` (read-only): poll an Asana Job by GID

### Important: instantiation is asynchronous

The Asana `POST /task_templates/{gid}/instantiateTask` endpoint returns a **Job**, not a **Task**. The new task GID is exposed via the job's `new_task` field once `status` becomes `succeeded`. Callers must:

1. Call `asana_instantiate_task` to start the operation
2. Poll `asana_get_job` with the returned `job.gid`
3. Read `job.new_task.gid` once `job.status === "succeeded"`

The `asana_instantiate_task` response wraps the Job and includes a `note` field reminding the caller of this contract.

In practice the job often returns `succeeded` on the very first poll for simple templates, but the contract is async by design and templates with many subtasks may take longer.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All four tools are listed by `tools/list`
- [x] `asana_get_task_templates` returns templates for a real project
- [x] `asana_get_task_template` returns the full template record (subtasks, custom fields, etc.)
- [x] `asana_instantiate_task` creates a real task and returns a Job whose `new_task.gid` resolves to that task
- [x] `asana_get_job` returns the job record with `status: succeeded` and the populated `new_task` field
- [x] Test task was deleted after verification
- [x] Read-only mode includes the three new read-only tools and excludes `asana_instantiate_task`
- [x] README and CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)