### PR TITLE
feat: add attachment tools (upload/list/get/delete)

### DIFF
--- a/scripts/test-attachments.mjs
+++ b/scripts/test-attachments.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Live test driver for the attachment tools.
+// Usage: node scripts/test-attachments.mjs <TASK_GID> <FILE_PATH>
+// Token: ASANA_ACCESS_TOKEN env, or first CLI arg file local/scripts/asana/.asana_pat.
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { readFileSync, existsSync } from 'node:fs';
+
+const [taskGid, filePath] = process.argv.slice(2);
+if (!taskGid || !filePath) {
+  console.error('Usage: node scripts/test-attachments.mjs <TASK_GID> <FILE_PATH>');
+  process.exit(2);
+}
+
+let token = process.env.ASANA_ACCESS_TOKEN;
+if (!token) {
+  const tokenFile = 'C:/Users/Victor.Perez/Projects/Tip-Top-Poultry/local/scripts/asana/.asana_pat';
+  if (existsSync(tokenFile)) token = readFileSync(tokenFile, 'utf8').trim();
+}
+if (!token) { console.error('No Asana token found (ASANA_ACCESS_TOKEN or .asana_pat).'); process.exit(2); }
+
+const srv = spawn('node', ['dist/index.js'], {
+  env: { ...process.env, ASANA_ACCESS_TOKEN: token },
+  stdio: ['pipe', 'pipe', 'inherit'],
+});
+
+const rl = createInterface({ input: srv.stdout });
+const pending = new Map();
+let nextId = 1;
+rl.on('line', (line) => {
+  line = line.trim();
+  if (!line) return;
+  let msg;
+  try { msg = JSON.parse(line); } catch { return; }
+  if (msg.id != null && pending.has(msg.id)) {
+    pending.get(msg.id)(msg);
+    pending.delete(msg.id);
+  }
+});
+
+const send = (obj) => srv.stdin.write(JSON.stringify(obj) + '\n');
+const rpc = (method, params) => new Promise((resolve) => {
+  const id = nextId++;
+  pending.set(id, resolve);
+  send({ jsonrpc: '2.0', id, method, params });
+});
+const callTool = async (name, args) => {
+  const r = await rpc('tools/call', { name, arguments: args });
+  const text = r.result?.content?.[0]?.text ?? JSON.stringify(r.error ?? r);
+  let parsed; try { parsed = JSON.parse(text); } catch { parsed = text; }
+  return { isError: r.result?.isError, parsed };
+};
+
+const ok = (b) => (b ? 'PASS' : 'FAIL');
+let allPass = true;
+const mark = (b) => { if (!b) allPass = false; return ok(b); };
+
+(async () => {
+  await rpc('initialize', {
+    capabilities: {}, clientInfo: { name: 'attach-test', version: '1' },
+    protocolVersion: '2024-11-05',
+  });
+  send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+  console.log(`\n1) asana_create_attachment  (upload ${filePath} -> task ${taskGid})`);
+  const created = await callTool('asana_create_attachment', { parent: taskGid, file_path: filePath });
+  const attGid = created.parsed?.gid;
+  console.log('   ', mark(!!attGid && !created.isError), '->', JSON.stringify(created.parsed));
+
+  if (!attGid) { console.log('\nRESULT:', mark(false)); srv.kill(); process.exit(1); }
+
+  console.log(`\n2) asana_get_attachments_for_object  (parent ${taskGid})`);
+  const list = await callTool('asana_get_attachments_for_object', { parent: taskGid });
+  const found = Array.isArray(list.parsed) && list.parsed.some(a => a.gid === attGid);
+  console.log('   ', mark(found), '->', JSON.stringify(list.parsed));
+
+  console.log(`\n3) asana_get_attachment  (${attGid})`);
+  const got = await callTool('asana_get_attachment', { attachment_gid: attGid, opt_fields: 'name,resource_type,download_url,parent' });
+  console.log('   ', mark(got.parsed?.gid === attGid), '->', JSON.stringify(got.parsed));
+
+  console.log(`\n4) asana_delete_attachment  (${attGid})  [cleanup]`);
+  const del = await callTool('asana_delete_attachment', { attachment_gid: attGid });
+  console.log('   ', mark(!del.isError), '->', JSON.stringify(del.parsed));
+
+  console.log('\nRESULT:', allPass ? 'ALL PASS' : 'SOME FAILED');
+  srv.kill();
+  process.exit(allPass ? 0 : 1);
+})();

--- a/src/asana-client-wrapper.ts
+++ b/src/asana-client-wrapper.ts
@@ -1,4 +1,5 @@
 import Asana from 'asana';
+import fs from 'fs';
 
 export class AsanaClientWrapper {
   private workspaces: any;
@@ -10,6 +11,7 @@ export class AsanaClientWrapper {
   private customFieldSettings: any;
   private sections: any;
   private userTaskLists: any;
+  private attachments: any;
 
   constructor(token: string) {
     const client = Asana.ApiClient.instance;
@@ -25,6 +27,55 @@ export class AsanaClientWrapper {
     this.customFieldSettings = new Asana.CustomFieldSettingsApi();
     this.sections = new Asana.SectionsApi();
     this.userTaskLists = new Asana.UserTaskListsApi();
+    this.attachments = new Asana.AttachmentsApi();
+  }
+
+  async createAttachment(parent: string, opts: any = {}) {
+    const { file_path, url, name, resource_subtype } = opts;
+
+    if (file_path && url) {
+      throw new Error("Provide either file_path or url, not both.");
+    }
+    if (!file_path && !url) {
+      throw new Error("Provide a file_path (to upload a local file) or a url (to attach an external link).");
+    }
+
+    const apiOpts: any = { parent };
+
+    if (file_path) {
+      if (!fs.existsSync(file_path)) {
+        throw new Error(`File not found: ${file_path}`);
+      }
+      // A ReadStream is recognized by the SDK as a file param; superagent
+      // derives the multipart filename from the stream's path.
+      apiOpts.file = fs.createReadStream(file_path);
+      apiOpts.resource_subtype = resource_subtype || 'asana';
+    } else {
+      apiOpts.url = url;
+      apiOpts.resource_subtype = resource_subtype || 'external';
+      // Asana requires a name for external (URL) attachments.
+      apiOpts.name = name || url;
+    }
+
+    if (name) apiOpts.name = name;
+
+    const response = await this.attachments.createAttachmentForObject(apiOpts);
+    return response.data;
+  }
+
+  async getAttachmentsForObject(parent: string, opts: any = {}) {
+    const response = await this.attachments.getAttachmentsForObject(parent, opts);
+    return response.data;
+  }
+
+  async getAttachment(attachmentGid: string, opts: any = {}) {
+    const response = await this.attachments.getAttachment(attachmentGid, opts);
+    return response.data;
+  }
+
+  async deleteAttachment(attachmentGid: string) {
+    const response = await this.attachments.deleteAttachment(attachmentGid);
+    return response.data;
   }
 
   async listWorkspaces(opts: any = {}) {

--- a/src/tool-handler.ts
+++ b/src/tool-handler.ts
@@ -57,6 +57,12 @@ import {
   getStoriesForTaskTool,
   createTaskStoryTool
 } from './tools/story-tools.js';
+import {
+  createAttachmentTool,
+  getAttachmentsForObjectTool,
+  getAttachmentTool,
+  deleteAttachmentTool
+} from './tools/attachment-tools.js';
 
 // List of all available tools
 const all_tools: Tool[] = [
@@ -101,6 +107,10 @@ const all_tools: Tool[] = [
   deleteSectionTool,
   addTaskToSectionTool,
   updateProjectTool,
+  createAttachmentTool,
+  getAttachmentsForObjectTool,
+  getAttachmentTool,
+  deleteAttachmentTool,
 ];
 
 // List of tools that only read Asana state
@@ -122,7 +132,9 @@ const READ_ONLY_TOOLS = [
   'asana_get_tags_for_task',
   'asana_get_tasks_for_tag',
   'asana_get_tags_for_workspace',
-  'asana_get_subtasks'
+  'asana_get_subtasks',
+  'asana_get_attachments_for_object',
+  'asana_get_attachment'
 ];
 
 // Filter tools based on READ_ONLY_MODE
@@ -688,6 +700,38 @@ export function tool_handler(asanaClient: AsanaClientWrapper): (request: CallToo
             }
             throw error;
           }
+        }
+
+        case "asana_create_attachment": {
+          const { parent, ...opts } = args;
+          const response = await asanaClient.createAttachment(parent, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_attachments_for_object": {
+          const { parent, ...opts } = args;
+          const response = await asanaClient.getAttachmentsForObject(parent, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_get_attachment": {
+          const { attachment_gid, ...opts } = args;
+          const response = await asanaClient.getAttachment(attachment_gid, opts);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        case "asana_delete_attachment": {
+          const { attachment_gid } = args;
+          await asanaClient.deleteAttachment(attachment_gid);
+          return {
+            content: [{ type: "text", text: `Successfully deleted attachment ${attachment_gid}` }],
+          };
         }
 
         default:

--- a/src/tools/attachment-tools.ts
+++ b/src/tools/attachment-tools.ts
@@ -1,0 +1,94 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const createAttachmentTool: Tool = {
+  name: "asana_create_attachment",
+  description: "Attach a file to a task, project, or project brief. Either upload a local file (file_path) or attach an external URL (url). Local files are uploaded with resource_subtype 'asana'; URLs use resource_subtype 'external'.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      parent: {
+        type: "string",
+        description: "The GID of the task, project, or project_brief to attach to"
+      },
+      file_path: {
+        type: "string",
+        description: "Absolute path to a local file to upload (e.g. a .md file). Provide either file_path or url, not both."
+      },
+      url: {
+        type: "string",
+        description: "External URL to attach instead of uploading a file. Requires resource_subtype 'external'."
+      },
+      name: {
+        type: "string",
+        description: "Name for the attachment. Optional for uploads (defaults to the file name); recommended for URL attachments."
+      },
+      resource_subtype: {
+        type: "string",
+        enum: ["asana", "external"],
+        description: "Attachment type. 'asana' for an uploaded file (default when file_path is given), 'external' for a URL (default when url is given)."
+      }
+    },
+    required: ["parent"]
+  }
+};
+
+export const getAttachmentsForObjectTool: Tool = {
+  name: "asana_get_attachments_for_object",
+  description: "List all attachments on a task, project, or project brief. Returns attachment GIDs, names, and download/view URLs.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      parent: {
+        type: "string",
+        description: "The GID of the task, project, or project_brief to list attachments for"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of attachments to return (1-100)"
+      },
+      offset: {
+        type: "string",
+        description: "Pagination offset token from a previous response"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["parent"]
+  }
+};
+
+export const getAttachmentTool: Tool = {
+  name: "asana_get_attachment",
+  description: "Get the full record for a single attachment, including name, download_url, view_url, and parent.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      attachment_gid: {
+        type: "string",
+        description: "The GID of the attachment to retrieve"
+      },
+      opt_fields: {
+        type: "string",
+        description: "Comma-separated list of optional fields to include"
+      }
+    },
+    required: ["attachment_gid"]
+  }
+};
+
+export const deleteAttachmentTool: Tool = {
+  name: "asana_delete_attachment",
+  description: "Delete an attachment by its GID. This cannot be undone.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      attachment_gid: {
+        type: "string",
+        description: "The GID of the attachment to delete"
+      }
+    },
+    required: ["attachment_gid"]
+  }
+};


### PR DESCRIPTION
Adds four Asana attachment tools:

- `asana_create_attachment` — upload a document to a task
- `asana_get_attachments_for_object` — list attachments on a task
- `asana_get_attachment` — fetch a single attachment's metadata
- `asana_delete_attachment` — remove an attachment

Changes: new `src/tools/attachment-tools.ts`, wired into `tool-handler.ts` and `asana-client-wrapper.ts`, plus a `scripts/test-attachments.mjs` smoke test.

Opening as a marker for discoverability — happy to add a CHANGELOG entry and README docs if you'd like to merge.